### PR TITLE
Add benchmarks for jsoniter-scala

### DIFF
--- a/benchmarks/src/main/scala/io/bullet/borer/benchmarks/AbstractBenchmarks.scala
+++ b/benchmarks/src/main/scala/io/bullet/borer/benchmarks/AbstractBenchmarks.scala
@@ -25,6 +25,8 @@ import scala.util.Random
   * > sbt "jmh:run -i 10 -wi 10 -f 2 -t 1 io.bullet.borer.benchmarks.*EncodingBenchmark"
   */
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class EncodingBenchmark extends EncodingDecodingExampleData
@@ -37,6 +39,8 @@ abstract class EncodingBenchmark extends EncodingDecodingExampleData
   * > sbt "jmh:run -i 10 -wi 10 -f 2 -t 1 io.bullet.borer.benchmarks.*DecodingBenchmark"
   */
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class DecodingBenchmark extends EncodingDecodingExampleData
@@ -49,6 +53,8 @@ abstract class DecodingBenchmark extends EncodingDecodingExampleData
   * > sbt "jmh:run -i 10 -wi 10 -f 2 -t 1 io.bullet.borer.benchmarks.*DomBenchmark"
   */
 @State(Scope.Thread)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 abstract class DomBenchmark {
@@ -73,7 +79,7 @@ abstract class DomBenchmark {
       "turkish.json",
       "twitter_api_compact_response.json",
       "twitter_api_response.json"))
-  var fileName: String = _
+  var fileName: String = "twitter_api_response.json"
 
   var fileBytes: Array[Byte] = _
 
@@ -95,7 +101,7 @@ object Foo {
 sealed abstract class EncodingDecodingExampleData {
 
   lazy val ints: List[Int] = {
-    val random = new Random()
+    val random = new Random(100L /* use the same seed for all benchmarks */ )
     Iterator.continually(random.nextInt(10000000)).take(10000).toList
   }
 

--- a/benchmarks/src/main/scala/io/bullet/borer/benchmarks/JsoniterScalaDefinitions.scala
+++ b/benchmarks/src/main/scala/io/bullet/borer/benchmarks/JsoniterScalaDefinitions.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.benchmarks
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import io.bullet.borer.{Default, Nullable}
+import org.openjdk.jmh.annotations._
+
+object JsoniterScalaCodecs {
+
+  val foosCodec: JsonValueCodec[Map[String, Foo]] =
+    JsonCodecMaker.make[Map[String, Foo]](CodecMakerConfig())
+
+  val intsCodec: JsonValueCodec[List[Int]] =
+    JsonCodecMaker.make[List[Int]](CodecMakerConfig())
+}
+
+object JsoniterScalaConfig {
+  val writerConfig = WriterConfig(preferredBufSize = 4 * 1024 * 1024 /* 4Mb */ )
+}
+
+import io.bullet.borer.benchmarks.JsoniterScalaCodecs._
+import io.bullet.borer.benchmarks.JsoniterScalaConfig._
+
+class JsoniterScalaEncodingBenchmark extends EncodingBenchmark {
+
+  @Benchmark
+  def encodeFoos: Array[Byte] = writeToArray(foos, writerConfig)(foosCodec)
+
+  @Benchmark
+  def encodeInts: Array[Byte] = writeToArray(ints, writerConfig)(intsCodec)
+
+  @Benchmark
+  def encodeEmptyArray: Array[Byte] = writeToArray(List.empty[Int])(intsCodec)
+}
+
+class JsoniterScalaDecodingBenchmark extends DecodingBenchmark {
+
+  @Benchmark
+  def decodeFoos: Map[String, Foo] = readFromArray(foosJson)(foosCodec)
+
+  @Benchmark
+  def decodeInts: List[Int] = readFromArray(intsJson)(intsCodec)
+
+  @Benchmark
+  def decodeEmptyArray: List[Int] = readFromArray(emptyArrayJson)(intsCodec)
+}
+
+class JsoniterScalaModelBenchmark extends DomBenchmark {
+
+  private var root: Product = _
+
+  private var codec: JsonValueCodec[Product] = _
+
+  implicit val nullableDoubleCodec: JsonValueCodec[Nullable[Double]] = new JsonValueCodec[Nullable[Double]] {
+    override def decodeValue(in: JsonReader, default: Nullable[Double]): Nullable[Double] =
+      if (in.isNextToken('n')) in.readNullOrError(default, "expected Double or Null")
+      else {
+        in.rollbackToken()
+        in.readDouble()
+      }
+
+    override def encodeValue(x: Nullable[Double], out: JsonWriter): Unit = out.writeVal(x.value)
+
+    override val nullValue: Nullable[Double] = new Nullable(Default.get[Double])
+  }
+
+  implicit val nullableIntCodec: JsonValueCodec[Nullable[Int]] = new JsonValueCodec[Nullable[Int]] {
+    override def decodeValue(in: JsonReader, default: Nullable[Int]): Nullable[Int] =
+      if (in.isNextToken('n')) in.readNullOrError(default, "expected Int or Null")
+      else {
+        in.rollbackToken()
+        new Nullable(in.readInt())
+      }
+
+    override def encodeValue(x: Nullable[Int], out: JsonWriter): Unit = out.writeVal(x.value)
+
+    override val nullValue: Nullable[Int] = new Nullable(Default.get[Int])
+  }
+
+  implicit val nullableStringCodec: JsonValueCodec[Nullable[String]] = new JsonValueCodec[Nullable[String]] {
+    override def decodeValue(in: JsonReader, default: Nullable[String]): Nullable[String] =
+      if (in.isNextToken('n')) in.readNullOrError(default, "expected Int or Null")
+      else {
+        in.rollbackToken()
+        new Nullable(in.readString(null))
+      }
+
+    override def encodeValue(x: Nullable[String], out: JsonWriter): Unit =
+      if (x.value == null) out.writeNull()
+      else out.writeVal(x.value)
+
+    override val nullValue: Nullable[String] = new Nullable(Default.get[String])
+  }
+
+  def setup(): Unit = {
+    codec = (fileName match {
+      case "australia-abc.json"      => JsonCodecMaker.make[Australia.RootInterface](CodecMakerConfig())
+      case "bitcoin.json"            => JsonCodecMaker.make[Bitcoin.RootInterface](CodecMakerConfig())
+      case "doj-blog.json"           => JsonCodecMaker.make[DojBlog.RootInterface](CodecMakerConfig())
+      case "eu-lobby-country.json"   => JsonCodecMaker.make[EuLobbyCountry.RootInterface](CodecMakerConfig())
+      case "eu-lobby-financial.json" => JsonCodecMaker.make[EuLobbyFinancial.RootInterface](CodecMakerConfig())
+      case "eu-lobby-repr.json"      => JsonCodecMaker.make[EuLobbyRepr.RootInterface](CodecMakerConfig())
+      case "github-events.json"      => JsonCodecMaker.make[List[GithubEvents.RootInterface]](CodecMakerConfig())
+      case "github-gists.json"       => JsonCodecMaker.make[List[GithubGists.RootInterface]](CodecMakerConfig())
+      case "json-generator.json"     => JsonCodecMaker.make[List[JsonGenerator.RootInterface]](CodecMakerConfig())
+      case "meteorites.json"         => JsonCodecMaker.make[List[Meteorites.RootInterface]](CodecMakerConfig())
+      case "movies.json"             => JsonCodecMaker.make[List[Movies.RootInterface]](CodecMakerConfig())
+      case "reddit-scala.json"       => JsonCodecMaker.make[Reddit.RootInterface](CodecMakerConfig())
+      case "rick-morty.json"         => JsonCodecMaker.make[RickMorty.RootInterface](CodecMakerConfig())
+      case "temp-anomaly.json"       => JsonCodecMaker.make[TempAnomaly.RootInterface](CodecMakerConfig())
+      case "thai-cinemas.json"       => JsonCodecMaker.make[ThaiCinemas.RootInterface](CodecMakerConfig())
+      case "turkish.json"            => JsonCodecMaker.make[Turkish.RootInterface](CodecMakerConfig())
+      case "twitter_api_compact_response.json" | "twitter_api_response.json" =>
+        JsonCodecMaker.make[List[TwitterApiResponse.RootInterface]](CodecMakerConfig())
+    }).asInstanceOf[JsonValueCodec[Product]]
+    root = readFromArray(fileBytes)(codec)
+  }
+
+  @Benchmark
+  def encodeModel: Array[Byte] = writeToArray(root, writerConfig)(codec)
+
+  @Benchmark
+  def decodeModel: Product = readFromArray(fileBytes)(codec)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -239,13 +239,13 @@ lazy val benchmarks = project
   .settings(
     publishArtifact := false,
     libraryDependencies ++= Seq(
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.47.0",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.47.0" % Provided,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.48.2",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.48.2" % Provided,
       "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % "2.9.8",
       "com.lihaoyi"                           %% "upickle"               % "0.7.4",
-      "io.circe"                              %% "circe-core"            % "0.11.1",
+      "io.circe"                              %% "circe-core"            % "0.12.0-M1",
       "io.circe"                              %% "circe-derivation"      % "0.12.0-M1",
-      "io.circe"                              %% "circe-jawn"            % "0.11.1",
+      "io.circe"                              %% "circe-jawn"            % "0.12.0-M1",
       "io.spray"                              %% "spray-json"            % "1.3.5",
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -239,11 +239,13 @@ lazy val benchmarks = project
   .settings(
     publishArtifact := false,
     libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.module"  %% "jackson-module-scala" % "2.9.8",
-      "com.lihaoyi"                   %% "upickle"              % "0.7.4",
-      "io.circe"                      %% "circe-core"           % "0.11.1",
-      "io.circe"                      %% "circe-derivation"     % "0.12.0-M1",
-      "io.circe"                      %% "circe-jawn"           % "0.11.1",
-      "io.spray"                      %% "spray-json"           % "1.3.5",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.47.0",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.47.0" % Provided,
+      "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % "2.9.8",
+      "com.lihaoyi"                           %% "upickle"               % "0.7.4",
+      "io.circe"                              %% "circe-core"            % "0.11.1",
+      "io.circe"                              %% "circe-derivation"      % "0.12.0-M1",
+      "io.circe"                              %% "circe-jawn"            % "0.11.1",
+      "io.spray"                              %% "spray-json"            % "1.3.5",
     )
   )


### PR DESCRIPTION
@sirthias Thanks for the bench suit! So diversive workloads! 

JFYK, I have found that Borer 0.9.0 outperforms jsoniter-scala 0.47.0 in parsing of some messages where case classes have too many fields to parse in a hot-loop (~90 or more, like in `reddit-scala.json`).

Also, it helped to find [an issue](https://github.com/plokhotnyuk/jsoniter-scala/issues/287) with case classes that has 32, 64, etc. fields

Bellow are results of both parsers on my notebook with OpenJDK 11:
### jsoniter-scala
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                       (fileName)   Mode  Cnt       Score      Error  Units
[info] JsoniterScalaModelBenchmark.decodeModel                 australia-abc.json  thrpt    5   21967.906 ± 1746.788  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       bitcoin.json  thrpt    5   32899.698 ± 2063.908  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                      doj-blog.json  thrpt    5    5373.159 ±  152.063  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel              eu-lobby-country.json  thrpt    5   42421.083 ± 2976.315  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt    5    7816.742 ±  104.682  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt    5    3084.256 ±  299.346  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 github-events.json  thrpt    5    3897.806 ±   37.593  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  github-gists.json  thrpt    5    9029.286 ±  941.237  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                json-generator.json  thrpt    5   45934.193 ± 1965.535  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    meteorites.json  thrpt    5    1284.162 ±   52.458  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                        movies.json  thrpt    5     103.252 ±    1.138  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  reddit-scala.json  thrpt    5    2633.520 ±   26.382  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    rick-morty.json  thrpt    5   31354.180 ± 1351.290  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  temp-anomaly.json  thrpt    5   45692.197 ± 1740.369  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  thai-cinemas.json  thrpt    5   34854.963 ± 3368.925  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       turkish.json  thrpt    5     621.655 ±   52.564  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt    5   49388.139 ±  250.832  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel          twitter_api_response.json  thrpt    5   41175.069 ±  389.151  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                 australia-abc.json  thrpt    5   17017.090 ± 2294.860  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                       bitcoin.json  thrpt    5   54574.871 ±  891.949  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                      doj-blog.json  thrpt    5    2397.797 ±    8.361  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel              eu-lobby-country.json  thrpt    5   30957.100 ± 4159.665  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel            eu-lobby-financial.json  thrpt    5   11244.430 ±  850.009  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                 eu-lobby-repr.json  thrpt    5    3173.156 ±    5.666  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                 github-events.json  thrpt    5    4344.217 ±   82.729  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                  github-gists.json  thrpt    5    8661.939 ±   56.661  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                json-generator.json  thrpt    5   76583.562 ± 7675.512  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                    meteorites.json  thrpt    5    1298.139 ±    2.993  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                        movies.json  thrpt    5      97.220 ±    5.099  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                  reddit-scala.json  thrpt    5    5850.978 ±  315.216  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                    rick-morty.json  thrpt    5   35537.533 ±  200.995  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                  temp-anomaly.json  thrpt    5  130836.224 ± 3779.165  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                  thai-cinemas.json  thrpt    5   47765.793 ± 5328.250  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel                       turkish.json  thrpt    5     680.563 ±   53.296  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel  twitter_api_compact_response.json  thrpt    5   70981.552 ± 8654.732  ops/s
[info] JsoniterScalaModelBenchmark.encodeModel          twitter_api_response.json  thrpt    5   72710.033 ± 8286.549  ops/s
```
### Borer
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                               (fileName)   Mode  Cnt      Score      Error  Units
[info] BorerModelBenchmark.decodeModel                 australia-abc.json  thrpt    5  12973.821 ±  435.743  ops/s
[info] BorerModelBenchmark.decodeModel                       bitcoin.json  thrpt    5  18548.508 ± 2236.431  ops/s
[info] BorerModelBenchmark.decodeModel                      doj-blog.json  thrpt    5   3842.196 ±  271.666  ops/s
[info] BorerModelBenchmark.decodeModel              eu-lobby-country.json  thrpt    5  26240.354 ± 1069.575  ops/s
[info] BorerModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt    5   5050.531 ±   42.634  ops/s
[info] BorerModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt    5   2094.002 ±   33.674  ops/s
[info] BorerModelBenchmark.decodeModel                 github-events.json  thrpt    5   2873.735 ±  131.852  ops/s
[info] BorerModelBenchmark.decodeModel                  github-gists.json  thrpt    5   6270.788 ±  149.951  ops/s
[info] BorerModelBenchmark.decodeModel                json-generator.json  thrpt    5  24110.860 ±  338.608  ops/s
[info] BorerModelBenchmark.decodeModel                    meteorites.json  thrpt    5    731.396 ±   20.834  ops/s
[info] BorerModelBenchmark.decodeModel                        movies.json  thrpt    5     49.768 ±    1.597  ops/s
[info] BorerModelBenchmark.decodeModel                  reddit-scala.json  thrpt    5   3087.225 ±  200.847  ops/s
[info] BorerModelBenchmark.decodeModel                    rick-morty.json  thrpt    5  16458.631 ± 1934.838  ops/s
[info] BorerModelBenchmark.decodeModel                  temp-anomaly.json  thrpt    5  36273.004 ± 2576.495  ops/s
[info] BorerModelBenchmark.decodeModel                  thai-cinemas.json  thrpt    5  23447.275 ±  609.492  ops/s
[info] BorerModelBenchmark.decodeModel                       turkish.json  thrpt    5    326.427 ±   33.588  ops/s
[info] BorerModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt    5  33541.663 ±  815.795  ops/s
[info] BorerModelBenchmark.decodeModel          twitter_api_response.json  thrpt    5  23502.183 ±   96.724  ops/s
[info] BorerModelBenchmark.encodeModel                 australia-abc.json  thrpt    5   7030.249 ±   51.533  ops/s
[info] BorerModelBenchmark.encodeModel                       bitcoin.json  thrpt    5  17588.288 ±  410.173  ops/s
[info] BorerModelBenchmark.encodeModel                      doj-blog.json  thrpt    5   1724.224 ±   12.816  ops/s
[info] BorerModelBenchmark.encodeModel              eu-lobby-country.json  thrpt    5  17913.519 ±  150.094  ops/s
[info] BorerModelBenchmark.encodeModel            eu-lobby-financial.json  thrpt    5   3155.994 ±   30.442  ops/s
[info] BorerModelBenchmark.encodeModel                 eu-lobby-repr.json  thrpt    5   1247.968 ±    8.172  ops/s
[info] BorerModelBenchmark.encodeModel                 github-events.json  thrpt    5   2040.756 ±   10.658  ops/s
[info] BorerModelBenchmark.encodeModel                  github-gists.json  thrpt    5   3503.917 ±   89.063  ops/s
[info] BorerModelBenchmark.encodeModel                json-generator.json  thrpt    5  29309.195 ±   79.318  ops/s
[info] BorerModelBenchmark.encodeModel                    meteorites.json  thrpt    5    564.650 ±   14.809  ops/s
[info] BorerModelBenchmark.encodeModel                        movies.json  thrpt    5     37.810 ±    0.505  ops/s
[info] BorerModelBenchmark.encodeModel                  reddit-scala.json  thrpt    5   2108.860 ±   26.504  ops/s
[info] BorerModelBenchmark.encodeModel                    rick-morty.json  thrpt    5  11376.416 ±  843.751  ops/s
[info] BorerModelBenchmark.encodeModel                  temp-anomaly.json  thrpt    5  66785.734 ± 1263.151  ops/s
[info] BorerModelBenchmark.encodeModel                  thai-cinemas.json  thrpt    5  21973.951 ±  643.827  ops/s
[info] BorerModelBenchmark.encodeModel                       turkish.json  thrpt    5    340.449 ±   20.387  ops/s
[info] BorerModelBenchmark.encodeModel  twitter_api_compact_response.json  thrpt    5  20356.984 ±  620.225  ops/s
[info] BorerModelBenchmark.encodeModel          twitter_api_response.json  thrpt    5  18582.182 ± 2964.082  ops/s
```
## Jackson
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                 (fileName)   Mode  Cnt      Score      Error  Units
[info] JacksonModelBenchmark.decodeModel                 australia-abc.json  thrpt    5   9640.055 ±  154.962  ops/s
[info] JacksonModelBenchmark.decodeModel                       bitcoin.json  thrpt    5  14788.302 ±  177.847  ops/s
[info] JacksonModelBenchmark.decodeModel                      doj-blog.json  thrpt    5   3867.669 ±  325.992  ops/s
[info] JacksonModelBenchmark.decodeModel              eu-lobby-country.json  thrpt    5  33629.711 ±  200.833  ops/s
[info] JacksonModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt    5   5315.855 ±   69.552  ops/s
[info] JacksonModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt    5   2412.082 ±  224.597  ops/s
[info] JacksonModelBenchmark.decodeModel                 github-events.json  thrpt    5   2967.125 ±   46.540  ops/s
[info] JacksonModelBenchmark.decodeModel                  github-gists.json  thrpt    5   7214.918 ±   78.647  ops/s
[info] JacksonModelBenchmark.decodeModel                json-generator.json  thrpt    5  21823.028 ±  103.701  ops/s
[info] JacksonModelBenchmark.decodeModel                    meteorites.json  thrpt    5    791.469 ±    9.383  ops/s
[info] JacksonModelBenchmark.decodeModel                        movies.json  thrpt    5     24.541 ±    0.641  ops/s
[info] JacksonModelBenchmark.decodeModel                  reddit-scala.json  thrpt    5   2856.821 ±  254.216  ops/s
[info] JacksonModelBenchmark.decodeModel                    rick-morty.json  thrpt    5  19595.194 ±  530.582  ops/s
[info] JacksonModelBenchmark.decodeModel                  temp-anomaly.json  thrpt    5  32928.180 ± 1448.088  ops/s
[info] JacksonModelBenchmark.decodeModel                  thai-cinemas.json  thrpt    5  25503.427 ±  212.422  ops/s
[info] JacksonModelBenchmark.decodeModel                       turkish.json  thrpt    5    429.388 ±    3.893  ops/s
[info] JacksonModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt    5  26755.528 ±  883.811  ops/s
[info] JacksonModelBenchmark.decodeModel          twitter_api_response.json  thrpt    5  18988.700 ±  162.400  ops/s
[info] JacksonModelBenchmark.encodeModel                 australia-abc.json  thrpt    5  12177.324 ±  130.271  ops/s
[info] JacksonModelBenchmark.encodeModel                       bitcoin.json  thrpt    5  25324.262 ±  382.139  ops/s
[info] JacksonModelBenchmark.encodeModel                      doj-blog.json  thrpt    5   2310.215 ±   26.993  ops/s
[info] JacksonModelBenchmark.encodeModel              eu-lobby-country.json  thrpt    5  36612.848 ±  966.748  ops/s
[info] JacksonModelBenchmark.encodeModel            eu-lobby-financial.json  thrpt    5   9513.191 ±  483.989  ops/s
[info] JacksonModelBenchmark.encodeModel                 eu-lobby-repr.json  thrpt    5   2235.690 ±    4.474  ops/s
[info] JacksonModelBenchmark.encodeModel                 github-events.json  thrpt    5   3178.480 ±   61.843  ops/s
[info] JacksonModelBenchmark.encodeModel                  github-gists.json  thrpt    5   8310.023 ±  103.032  ops/s
[info] JacksonModelBenchmark.encodeModel                json-generator.json  thrpt    5  38440.709 ± 1083.986  ops/s
[info] JacksonModelBenchmark.encodeModel                    meteorites.json  thrpt    5    940.130 ±   11.318  ops/s
[info] JacksonModelBenchmark.encodeModel                        movies.json  thrpt    5     86.898 ±    2.843  ops/s
[info] JacksonModelBenchmark.encodeModel                  reddit-scala.json  thrpt    5   3864.755 ±   33.595  ops/s
[info] JacksonModelBenchmark.encodeModel                    rick-morty.json  thrpt    5  18922.142 ±  181.314  ops/s
[info] JacksonModelBenchmark.encodeModel                  temp-anomaly.json  thrpt    5  67836.752 ±  302.757  ops/s
[info] JacksonModelBenchmark.encodeModel                  thai-cinemas.json  thrpt    5  38321.765 ±  629.438  ops/s
[info] JacksonModelBenchmark.encodeModel                       turkish.json  thrpt    5    500.478 ±   44.155  ops/s
[info] JacksonModelBenchmark.encodeModel  twitter_api_compact_response.json  thrpt    5  41331.299 ±  265.281  ops/s
[info] JacksonModelBenchmark.encodeModel          twitter_api_response.json  thrpt    5  41818.340 ±  414.329  ops/s
```