### PR TITLE
 Use benchmark forking by default with JVM options optimized for throughput

### DIFF
--- a/benchmarks/src/main/scala/io/bullet/borer/benchmarks/AbstractBenchmarks.scala
+++ b/benchmarks/src/main/scala/io/bullet/borer/benchmarks/AbstractBenchmarks.scala
@@ -27,6 +27,21 @@ import scala.util.Random
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = Array(
+    "-server",
+    "-Xms2g",
+    "-Xmx2g",
+    "-XX:NewSize=1g",
+    "-XX:MaxNewSize=1g",
+    "-XX:InitialCodeCacheSize=512m",
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:+UseParallelGC",
+    "-XX:-UseBiasedLocking",
+    "-XX:+AlwaysPreTouch"))
 abstract class EncodingBenchmark extends EncodingDecodingExampleData
 
 /**
@@ -39,6 +54,21 @@ abstract class EncodingBenchmark extends EncodingDecodingExampleData
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = Array(
+    "-server",
+    "-Xms2g",
+    "-Xmx2g",
+    "-XX:NewSize=1g",
+    "-XX:MaxNewSize=1g",
+    "-XX:InitialCodeCacheSize=512m",
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:+UseParallelGC",
+    "-XX:-UseBiasedLocking",
+    "-XX:+AlwaysPreTouch"))
 abstract class DecodingBenchmark extends EncodingDecodingExampleData
 
 /**
@@ -51,6 +81,21 @@ abstract class DecodingBenchmark extends EncodingDecodingExampleData
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = Array(
+    "-server",
+    "-Xms2g",
+    "-Xmx2g",
+    "-XX:NewSize=1g",
+    "-XX:MaxNewSize=1g",
+    "-XX:InitialCodeCacheSize=512m",
+    "-XX:ReservedCodeCacheSize=512m",
+    "-XX:+UseParallelGC",
+    "-XX:-UseBiasedLocking",
+    "-XX:+AlwaysPreTouch"))
 abstract class DomBenchmark {
 
   @Param(

--- a/build.sbt
+++ b/build.sbt
@@ -234,8 +234,8 @@ lazy val benchmarks = project
   .settings(
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.52.0",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.52.0" % Provided,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.52.2",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.52.2" % Provided,
       "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % "2.9.9",
       "com.lihaoyi"                           %% "upickle"               % "0.7.5",
       "io.circe"                              %% "circe-core"            % "0.12.0-M4",


### PR DESCRIPTION
Results with JVM options by default:
```
[info] Benchmark                                                       (fileName)   Mode  Cnt      Score      Error  Units
[info] JsoniterScalaModelBenchmark.decodeModel                 australia-abc.json  thrpt   10  20420.329 ± 1435.605  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       bitcoin.json  thrpt   10  30424.475 ± 1511.010  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                      doj-blog.json  thrpt   10   4924.930 ±   58.693  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel              eu-lobby-country.json  thrpt   10  38296.769 ± 1697.700  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt   10   6304.175 ±   95.320  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt   10   2851.502 ±   33.075  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 github-events.json  thrpt   10   3487.667 ±   54.448  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  github-gists.json  thrpt   10   7449.918 ±   85.363  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                json-generator.json  thrpt   10  38420.920 ±  719.182  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    meteorites.json  thrpt   10   1142.487 ±    4.122  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                        movies.json  thrpt   10    100.595 ±    1.420  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  reddit-scala.json  thrpt   10   2390.566 ±    7.110  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    rick-morty.json  thrpt   10  24535.462 ±  114.332  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  temp-anomaly.json  thrpt   10  45453.553 ± 2921.340  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  thai-cinemas.json  thrpt   10  36143.824 ±  208.903  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       turkish.json  thrpt   10    551.216 ±    5.439  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt   10  47398.145 ± 1083.763  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel          twitter_api_response.json  thrpt   10  37425.216 ±  901.192  ops/s
```
Results with JVM options tuned as proposed in this PR:
```
[info] Benchmark                                                       (fileName)   Mode  Cnt      Score      Error  Units
[info] JsoniterScalaModelBenchmark.decodeModel                 australia-abc.json  thrpt   10  21649.097 ±   22.060  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       bitcoin.json  thrpt   10  31520.142 ±  226.260  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                      doj-blog.json  thrpt   10   5326.374 ±   36.634  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel              eu-lobby-country.json  thrpt   10  41513.690 ± 1735.500  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt   10   7318.161 ±  282.377  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt   10   3010.575 ±  111.712  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                 github-events.json  thrpt   10   3619.154 ±   97.391  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  github-gists.json  thrpt   10   9167.033 ±  100.082  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                json-generator.json  thrpt   10  41809.060 ±  230.901  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    meteorites.json  thrpt   10   1280.811 ±   35.623  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                        movies.json  thrpt   10    107.184 ±    2.842  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  reddit-scala.json  thrpt   10   2487.790 ±   29.516  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                    rick-morty.json  thrpt   10  25945.648 ±  124.043  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  temp-anomaly.json  thrpt   10  50455.435 ± 1998.859  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                  thai-cinemas.json  thrpt   10  37788.097 ± 1631.970  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel                       turkish.json  thrpt   10    561.694 ±   26.769  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt   10  50410.811 ± 3216.370  ops/s
[info] JsoniterScalaModelBenchmark.decodeModel          twitter_api_response.json  thrpt   10  39292.007 ± 1945.814  ops/s
```