### PR TITLE
More efficient serialization for Jackson model benchmarks

### DIFF
--- a/benchmarks/src/main/scala/io/bullet/borer/benchmarks/JacksonDefinitions.scala
+++ b/benchmarks/src/main/scala/io/bullet/borer/benchmarks/JacksonDefinitions.scala
@@ -10,12 +10,12 @@ package io.bullet.borer.benchmarks
 
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.openjdk.jmh.annotations._
 
 object JacksonCodecs {
-  val mapper: ObjectMapper = new ObjectMapper()
-  mapper.registerModule(DefaultScalaModule)
+  val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule).registerModule(new AfterburnerModule)
 
   val foosTypeRef = new TypeReference[Map[String, Foo]] {}
   val intsTypeRef = new TypeReference[List[Int]]        {}

--- a/build.sbt
+++ b/build.sbt
@@ -322,14 +322,15 @@ lazy val benchmarks = project
   .settings(
     skip in publish := true,
     libraryDependencies ++= Seq(
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "0.55.2",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.55.2" % Provided,
-      "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % "2.9.10",
-      "com.lihaoyi"                           %% "upickle"               % "0.8.0",
-      "io.circe"                              %% "circe-core"            % "0.12.1",
-      "io.circe"                              %% "circe-derivation"      % "0.12.0-M7",
-      "io.circe"                              %% "circe-jawn"            % "0.12.1",
-      "io.spray"                              %% "spray-json"            % "1.3.5",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"        % "0.55.2",
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"      % "0.55.2" % Provided,
+      "com.fasterxml.jackson.module"          %% "jackson-module-scala"       % "2.10.0",
+      "com.fasterxml.jackson.module"          %  "jackson-module-afterburner" % "2.10.0",
+      "com.lihaoyi"                           %% "upickle"                    % "0.8.0",
+      "io.circe"                              %% "circe-core"                 % "0.12.1",
+      "io.circe"                              %% "circe-derivation"           % "0.12.0-M7",
+      "io.circe"                              %% "circe-jawn"                 % "0.12.1",
+      "io.spray"                              %% "spray-json"                 % "1.3.5",
     )
   )
 


### PR DESCRIPTION
In most cases speed up is ~15%, but it can be different from -5% to 40% depending on payload.

## Before
```
[info] Benchmark                                                 (fileName)   Mode  Cnt      Score   Error  Units
[info] JacksonModelBenchmark.decodeModel                 australia-abc.json  thrpt       11748.133          ops/s
[info] JacksonModelBenchmark.decodeModel                       bitcoin.json  thrpt       17663.037          ops/s
[info] JacksonModelBenchmark.decodeModel                      doj-blog.json  thrpt        4792.250          ops/s
[info] JacksonModelBenchmark.decodeModel              eu-lobby-country.json  thrpt       35625.988          ops/s
[info] JacksonModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt        5924.326          ops/s
[info] JacksonModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt        2578.333          ops/s
[info] JacksonModelBenchmark.decodeModel                 github-events.json  thrpt        3374.938          ops/s
[info] JacksonModelBenchmark.decodeModel                  github-gists.json  thrpt        7686.731          ops/s
[info] JacksonModelBenchmark.decodeModel                json-generator.json  thrpt       27253.949          ops/s
[info] JacksonModelBenchmark.decodeModel                    meteorites.json  thrpt         844.449          ops/s
[info] JacksonModelBenchmark.decodeModel                        movies.json  thrpt          46.970          ops/s
[info] JacksonModelBenchmark.decodeModel                  reddit-scala.json  thrpt        3296.361          ops/s
[info] JacksonModelBenchmark.decodeModel                    rick-morty.json  thrpt       21722.358          ops/s
[info] JacksonModelBenchmark.decodeModel                  temp-anomaly.json  thrpt       44813.033          ops/s
[info] JacksonModelBenchmark.decodeModel                  thai-cinemas.json  thrpt       26780.576          ops/s
[info] JacksonModelBenchmark.decodeModel                       turkish.json  thrpt         405.760          ops/s
[info] JacksonModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt       30502.869          ops/s
[info] JacksonModelBenchmark.decodeModel          twitter_api_response.json  thrpt       22823.400          ops/s
[info] JacksonModelBenchmark.encodeModel                 australia-abc.json  thrpt       13683.505          ops/s
[info] JacksonModelBenchmark.encodeModel                       bitcoin.json  thrpt       28555.509          ops/s
[info] JacksonModelBenchmark.encodeModel                      doj-blog.json  thrpt        2328.998          ops/s
[info] JacksonModelBenchmark.encodeModel              eu-lobby-country.json  thrpt       35022.251          ops/s
[info] JacksonModelBenchmark.encodeModel            eu-lobby-financial.json  thrpt        8841.966          ops/s
[info] JacksonModelBenchmark.encodeModel                 eu-lobby-repr.json  thrpt        2412.273          ops/s
[info] JacksonModelBenchmark.encodeModel                 github-events.json  thrpt        3370.930          ops/s
[info] JacksonModelBenchmark.encodeModel                  github-gists.json  thrpt        8152.262          ops/s
[info] JacksonModelBenchmark.encodeModel                json-generator.json  thrpt       38841.360          ops/s
[info] JacksonModelBenchmark.encodeModel                    meteorites.json  thrpt         960.789          ops/s
[info] JacksonModelBenchmark.encodeModel                        movies.json  thrpt          71.776          ops/s
[info] JacksonModelBenchmark.encodeModel                  reddit-scala.json  thrpt        3810.104          ops/s
[info] JacksonModelBenchmark.encodeModel                    rick-morty.json  thrpt       21305.935          ops/s
[info] JacksonModelBenchmark.encodeModel                  temp-anomaly.json  thrpt       69522.837          ops/s
[info] JacksonModelBenchmark.encodeModel                  thai-cinemas.json  thrpt       35996.926          ops/s
[info] JacksonModelBenchmark.encodeModel                       turkish.json  thrpt         532.422          ops/s
[info] JacksonModelBenchmark.encodeModel  twitter_api_compact_response.json  thrpt       43514.771          ops/s
[info] JacksonModelBenchmark.encodeModel          twitter_api_response.json  thrpt       40331.827          ops/s
```
## After
```
[info] Benchmark                                                 (fileName)   Mode  Cnt      Score   Error  Units
[info] JacksonModelBenchmark.decodeModel                 australia-abc.json  thrpt       11457.469          ops/s
[info] JacksonModelBenchmark.decodeModel                       bitcoin.json  thrpt       17681.061          ops/s
[info] JacksonModelBenchmark.decodeModel                      doj-blog.json  thrpt        4808.440          ops/s
[info] JacksonModelBenchmark.decodeModel              eu-lobby-country.json  thrpt       34637.045          ops/s
[info] JacksonModelBenchmark.decodeModel            eu-lobby-financial.json  thrpt        5929.782          ops/s
[info] JacksonModelBenchmark.decodeModel                 eu-lobby-repr.json  thrpt        2587.276          ops/s
[info] JacksonModelBenchmark.decodeModel                 github-events.json  thrpt        3297.670          ops/s
[info] JacksonModelBenchmark.decodeModel                  github-gists.json  thrpt        7318.149          ops/s
[info] JacksonModelBenchmark.decodeModel                json-generator.json  thrpt       27446.356          ops/s
[info] JacksonModelBenchmark.decodeModel                    meteorites.json  thrpt         836.429          ops/s
[info] JacksonModelBenchmark.decodeModel                        movies.json  thrpt          46.190          ops/s
[info] JacksonModelBenchmark.decodeModel                  reddit-scala.json  thrpt        3253.615          ops/s
[info] JacksonModelBenchmark.decodeModel                    rick-morty.json  thrpt       20504.409          ops/s
[info] JacksonModelBenchmark.decodeModel                  temp-anomaly.json  thrpt       44264.933          ops/s
[info] JacksonModelBenchmark.decodeModel                  thai-cinemas.json  thrpt       26509.977          ops/s
[info] JacksonModelBenchmark.decodeModel                       turkish.json  thrpt         381.942          ops/s
[info] JacksonModelBenchmark.decodeModel  twitter_api_compact_response.json  thrpt       30270.997          ops/s
[info] JacksonModelBenchmark.decodeModel          twitter_api_response.json  thrpt       22370.098          ops/s
[info] JacksonModelBenchmark.encodeModel                 australia-abc.json  thrpt       14559.158          ops/s
[info] JacksonModelBenchmark.encodeModel                       bitcoin.json  thrpt       34910.652          ops/s
[info] JacksonModelBenchmark.encodeModel                      doj-blog.json  thrpt        2906.695          ops/s
[info] JacksonModelBenchmark.encodeModel              eu-lobby-country.json  thrpt       50721.471          ops/s
[info] JacksonModelBenchmark.encodeModel            eu-lobby-financial.json  thrpt       10712.730          ops/s
[info] JacksonModelBenchmark.encodeModel                 eu-lobby-repr.json  thrpt        2671.724          ops/s
[info] JacksonModelBenchmark.encodeModel                 github-events.json  thrpt        3337.834          ops/s
[info] JacksonModelBenchmark.encodeModel                  github-gists.json  thrpt       10292.194          ops/s
[info] JacksonModelBenchmark.encodeModel                json-generator.json  thrpt       43734.113          ops/s
[info] JacksonModelBenchmark.encodeModel                    meteorites.json  thrpt        1039.759          ops/s
[info] JacksonModelBenchmark.encodeModel                        movies.json  thrpt          89.580          ops/s
[info] JacksonModelBenchmark.encodeModel                  reddit-scala.json  thrpt        4507.340          ops/s
[info] JacksonModelBenchmark.encodeModel                    rick-morty.json  thrpt       24475.935          ops/s
[info] JacksonModelBenchmark.encodeModel                  temp-anomaly.json  thrpt       69032.883          ops/s
[info] JacksonModelBenchmark.encodeModel                  thai-cinemas.json  thrpt       43686.450          ops/s
[info] JacksonModelBenchmark.encodeModel                       turkish.json  thrpt         493.221          ops/s
[info] JacksonModelBenchmark.encodeModel  twitter_api_compact_response.json  thrpt       51935.737          ops/s
[info] JacksonModelBenchmark.encodeModel          twitter_api_response.json  thrpt       53076.890          ops/s
```