### PR TITLE
Added compat-pekko, as alternative to compat-akka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ project/plugins/target
 project/plugins/project/build.properties
 buildinfo.properties
 proguard-sbt.txt
+/.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val commonSettings = Seq(
 
   // temp
   resolvers += "jitpack" at "https://jitpack.io",
+  resolvers += "Apache Pekko Staging".at("https://repository.apache.org/content/groups/staging"),
 
   // file headers
   headerLicense := Some(HeaderLicense.MPLv2("2019-2023", "Mathias Doenitz")),
@@ -110,10 +111,9 @@ val `akka-actor`        = Def.setting("com.typesafe.akka" %%  "akka-actor-typed"
 val `akka-stream`       = Def.setting("com.typesafe.akka" %%  "akka-stream"       % "2.8.0")
 val `akka-http`         = Def.setting("com.typesafe.akka" %%  "akka-http"         % "10.5.1")
 
-val `pekko-actor`        = Def.setting("org.apache.pekko" %%  "pekko-actor-typed"  % "1.0.0")
-val `pekko-stream`       = Def.setting("org.apache.pekko" %%  "pekko-stream"       % "1.0.0")
-//val `pekko-http`         = Def.setting("org.apache.pekko" %%  "pekko-http"         % "1.0.0-RC1")
-val `pekko-http`         = Def.setting("com.github.apache.incubator-pekko-http" %%  "pekko-http" % "1.0.0-RC1")
+val `pekko-actor`        = Def.setting("org.apache.pekko" %%  "pekko-actor-typed"  % "1.0.1")
+val `pekko-stream`       = Def.setting("org.apache.pekko" %%  "pekko-stream"       % "1.0.1")
+val `pekko-http`         = Def.setting("org.apache.pekko" %%  "pekko-http"         % "1.0.0-RC2")
 
 val `cats-core`         = Def.setting("org.typelevel"     %%% "cats-core"         % "2.9.0")
 val `circe-core`        = Def.setting("io.circe"          %%% "circe-core"        % "0.14.5")

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ addCommandAlias("check", "; scalafmtCheckAll")
 
 addCommandAlias(
   "testJVM",
-  Seq("core", "derivation", "compat-akka", "compat-cats", "compat-circe", "compat-scodec", "site")
+  Seq("core", "derivation", "compat-akka", "compat-pekko", "compat-cats", "compat-circe", "compat-scodec", "site")
     .mkString("; ", "/test ; ", "/test")
 )
 
@@ -61,6 +61,9 @@ lazy val commonSettings = Seq(
   sourcesInBase := false,
   Compile / unmanagedResources += baseDirectory.value.getParentFile.getParentFile / "LICENSE",
   scalafmtOnCompile := true, // reformat main and test sources on compile
+
+  // temp
+  resolvers += "jitpack" at "https://jitpack.io",
 
   // file headers
   headerLicense := Some(HeaderLicense.MPLv2("2019-2023", "Mathias Doenitz")),
@@ -106,6 +109,12 @@ lazy val releaseSettings = {
 val `akka-actor`        = Def.setting("com.typesafe.akka" %%  "akka-actor-typed"  % "2.8.0")
 val `akka-stream`       = Def.setting("com.typesafe.akka" %%  "akka-stream"       % "2.8.0")
 val `akka-http`         = Def.setting("com.typesafe.akka" %%  "akka-http"         % "10.5.1")
+
+val `pekko-actor`        = Def.setting("org.apache.pekko" %%  "pekko-actor-typed"  % "1.0.0")
+val `pekko-stream`       = Def.setting("org.apache.pekko" %%  "pekko-stream"       % "1.0.0")
+//val `pekko-http`         = Def.setting("org.apache.pekko" %%  "pekko-http"         % "1.0.0-RC1")
+val `pekko-http`         = Def.setting("com.github.apache.incubator-pekko-http" %%  "pekko-http" % "1.0.0-RC1")
+
 val `cats-core`         = Def.setting("org.typelevel"     %%% "cats-core"         % "2.9.0")
 val `circe-core`        = Def.setting("io.circe"          %%% "circe-core"        % "0.14.5")
 val `circe-parser`      = Def.setting("io.circe"          %%% "circe-parser"      % "0.14.5")
@@ -120,6 +129,7 @@ val macrolizer          = Def.setting("io.bullet"         %%% "macrolizer"      
 lazy val borer = (project in file("."))
   .aggregate(`core-jvm`, `core-js`)
   .aggregate(`compat-akka`)
+  .aggregate(`compat-pekko`)
   .aggregate(`compat-cats-jvm`, `compat-cats-js`)
   .aggregate(`compat-circe-jvm`, `compat-circe-js`)
   .aggregate(`compat-scodec-jvm`, `compat-scodec-js`)
@@ -164,6 +174,21 @@ lazy val `compat-akka` = project
       `akka-actor`.value  % "provided",
       `akka-stream`.value % "provided",
       `akka-http`.value   % "provided" cross CrossVersion.for3Use2_13,
+      munit.value)
+  )
+
+lazy val `compat-pekko` = project
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(`core-jvm` % "compile->compile;test->test")
+  .dependsOn(`derivation-jvm` % "test->compile")
+  .settings(commonSettings)
+  .settings(releaseSettings)
+  .settings(
+    moduleName := "borer-compat-pekko",
+    libraryDependencies ++= Seq(
+      `pekko-actor`.value  % "provided",
+      `pekko-stream`.value % "provided",
+      `pekko-http`.value   % "provided" cross CrossVersion.for3Use2_13,
       munit.value)
   )
 
@@ -269,6 +294,7 @@ lazy val site = project
     `core-jvm` % "compile->compile;test->test",
     `derivation-jvm`,
     `compat-akka`,
+    `compat-pekko`,
     `compat-cats-jvm`,
     `compat-circe-jvm`,
     `compat-scodec-jvm`
@@ -286,6 +312,9 @@ lazy val site = project
       `akka-actor`.value,
       `akka-stream`.value,
       `akka-http`.value.cross(CrossVersion.for3Use2_13),
+      `pekko-actor`.value,
+      `pekko-stream`.value,
+      `pekko-http`.value.cross(CrossVersion.for3Use2_13),
       munit.value
     ),
     com.github.sbt.git.SbtGit.GitKeys.gitRemoteRepo := scmInfo.value.get.connection.drop("scm:git:".length),

--- a/compat-pekko/src/main/scala/io/bullet/borer/compat/pekko.scala
+++ b/compat-pekko/src/main/scala/io/bullet/borer/compat/pekko.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import java.nio.ByteBuffer
+
+import _root_.org.apache.pekko.util.ByteString
+import _root_.org.apache.pekko.actor
+import _root_.org.apache.pekko.actor.typed.{ActorRef, ActorRefResolver, ActorSystem}
+import _root_.org.apache.pekko.serialization.Serialization
+import io.bullet.borer.{ByteAccess, _}
+
+object pekko {
+
+  implicit def actorRefCodec(implicit system: actor.ActorSystem = serializationSystem): Codec[actor.ActorRef] = {
+    val actorRefProvider = system.asInstanceOf[actor.ExtendedActorSystem].provider
+
+    Codec.bimap[String, actor.ActorRef](
+      Serialization.serializedActorPath,
+      actorRefProvider.resolveActorRef
+    )
+  }
+
+  implicit def typedActorRefCodec[T](implicit system: actor.ActorSystem = serializationSystem): Codec[ActorRef[T]] = {
+    val resolver = ActorRefResolver(ActorSystem.wrap(system))
+
+    Codec.bimap[String, ActorRef[T]](
+      resolver.toSerializationFormat,
+      resolver.resolveActorRef
+    )
+  }
+
+  private def serializationSystem: actor.ActorSystem = Serialization.getCurrentTransportInformation().system
+
+  /**
+   * [[ByteAccess]] for [[ByteString]].
+   */
+  implicit object ByteStringByteAccess extends ByteAccess[ByteString] {
+
+    type Out = ByteStringOutput
+
+    def isEmpty(bytes: ByteString): Boolean = bytes.isEmpty
+
+    def sizeOf(bytes: ByteString): Long = bytes.length.toLong
+
+    def fromByteArray(byteArray: Array[Byte]): ByteString = ByteString(byteArray)
+
+    def toByteArray(bytes: ByteString): Array[Byte] = bytes.toArray
+
+    def concat(a: ByteString, b: ByteString) =
+      if (a.nonEmpty) {
+        if (b.nonEmpty) {
+          val len = a.length + b.length
+          if (len >= 0) {
+            a ++ b
+          } else sys.error("Cannot concatenate two ByteStrings with a total size > 2^31 bytes")
+        } else a
+      } else b
+
+    def copyToByteArray(bytes: ByteString, byteArray: Array[Byte], startIndex: Int): ByteString = {
+      val len = byteArray.length - startIndex
+      bytes.copyToArray(byteArray, startIndex)
+      if (len < bytes.size) bytes.drop(len) else empty
+    }
+
+    def copyToByteBuffer(bytes: ByteString, byteBuffer: ByteBuffer): ByteString = {
+      val copied = bytes.copyToBuffer(byteBuffer)
+      if (copied < bytes.size) bytes.drop(copied) else empty
+    }
+
+    def convert[B](value: B)(implicit byteAccess: ByteAccess[B]) =
+      value match {
+        case x: ByteString => x
+        case x             => fromByteArray(byteAccess.toByteArray(x))
+      }
+
+    def empty = ByteString.empty
+  }
+
+  /**
+   * Encoding and Decoding for [[ByteString]].
+   */
+  implicit val ByteStringCodec: Codec[ByteString] = Codec[ByteString](_ writeBytes _, _.readBytes())
+
+  /**
+   * [[Input]] around [[ByteString]].
+   */
+  implicit object ByteStringProvider extends Input.Provider[ByteString] {
+    type Bytes = ByteString
+    type In    = FromByteString
+    def byteAccess               = ByteStringByteAccess
+    def apply(value: ByteString) = new FromByteString(value)
+  }
+
+  final class FromByteString(byteString: ByteString) extends Input[ByteString] {
+    private[this] var _cursor: Int = _
+
+    def cursor: Long = _cursor.toLong
+
+    def unread(numberOfBytes: Int): this.type = {
+      _cursor -= numberOfBytes
+      this
+    }
+
+    def readByte(): Byte = {
+      val c = _cursor
+      _cursor = c + 1
+      byteString(c)
+    }
+
+    def readBytePadded(pp: Input.PaddingProvider[ByteString]): Byte =
+      if (_cursor < byteString.length) readByte()
+      else pp.padByte()
+
+    def readDoubleByteBigEndian(): Char = {
+      val c = _cursor
+      _cursor = c + 2
+      ((byteString(c) << 8) | byteString(c + 1) & 0xFF).toChar
+    }
+
+    def readDoubleByteBigEndianPadded(pp: Input.PaddingProvider[ByteString]): Char = {
+      val remaining = byteString.length - _cursor
+      if (remaining >= 2) readDoubleByteBigEndian()
+      else pp.padDoubleByte(remaining)
+    }
+
+    def readQuadByteBigEndian(): Int = {
+      val c = _cursor
+      _cursor = c + 4
+      byteString(c) << 24 |
+      (byteString(c + 1) & 0xFF) << 16 |
+      (byteString(c + 2) & 0xFF) << 8 |
+      byteString(c + 3) & 0xFF
+    }
+
+    def readQuadByteBigEndianPadded(pp: Input.PaddingProvider[ByteString]): Int = {
+      val remaining = byteString.length - _cursor
+      if (remaining >= 4) readQuadByteBigEndian()
+      else pp.padQuadByte(remaining)
+    }
+
+    def readOctaByteBigEndian(): Long = {
+      val c = _cursor
+      _cursor = c + 8
+      byteString(c).toLong << 56 |
+      (byteString(c + 1) & 0xFFL) << 48 |
+      (byteString(c + 2) & 0xFFL) << 40 |
+      (byteString(c + 3) & 0xFFL) << 32 |
+      (byteString(c + 4) & 0xFFL) << 24 |
+      (byteString(c + 5) & 0xFFL) << 16 |
+      (byteString(c + 6) & 0xFFL) << 8 |
+      byteString(c + 7) & 0xFFL
+    }
+
+    def readOctaByteBigEndianPadded(pp: Input.PaddingProvider[ByteString]): Long = {
+      val remaining = byteString.length - _cursor
+      if (remaining >= 8) readOctaByteBigEndian()
+      else pp.padOctaByte(remaining)
+    }
+
+    def readBytes(length: Long, pp: Input.PaddingProvider[ByteString]) = {
+      val remaining = (byteString.length - _cursor).toLong
+      val len       = math.min(remaining, length).toInt
+      val bytes =
+        if (len > 0) {
+          val c = _cursor
+          _cursor = c + len
+          byteString.slice(c, _cursor)
+        } else ByteString.empty
+      if (length <= remaining) bytes
+      else pp.padBytes(bytes, length - remaining)
+    }
+  }
+
+  implicit object ByteStringOutputProvider extends Output.ToTypeProvider[ByteString] {
+    type Out = ByteStringOutput
+    def apply(bufferSize: Int, allowBufferCaching: Boolean) = new ByteStringOutput
+  }
+
+  /**
+   * Mutable [[Output]] implementation for serializing to [[ByteString]].
+   */
+  final class ByteStringOutput extends Output {
+    private[this] var builder = ByteString.newBuilder
+
+    type Self   = ByteStringOutput
+    type Result = ByteString
+
+    def cursor: Int = builder.length
+
+    def writeByte(byte: Byte): this.type = {
+      builder += byte
+      this
+    }
+
+    def writeBytes(a: Byte, b: Byte): this.type = {
+      builder += a
+      builder += b
+      this
+    }
+
+    def writeBytes(a: Byte, b: Byte, c: Byte): this.type = {
+      builder += a
+      builder += b
+      builder += c
+      this
+    }
+
+    def writeBytes(a: Byte, b: Byte, c: Byte, d: Byte): this.type = {
+      builder += a
+      builder += b
+      builder += c
+      builder += d
+      this
+    }
+
+    def writeBytes[Bytes: ByteAccess](bytes: Bytes): this.type = {
+      builder ++= ByteStringByteAccess.convert(bytes)
+      this
+    }
+
+    def result(): ByteString = builder.result()
+  }
+}

--- a/compat-pekko/src/main/scala/io/bullet/borer/compat/pekkoHttp.scala
+++ b/compat-pekko/src/main/scala/io/bullet/borer/compat/pekkoHttp.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+import _root_.org.apache.pekko.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import _root_.org.apache.pekko.http.scaladsl.unmarshalling.{
+  FromEntityUnmarshaller,
+  FromMessageUnmarshaller,
+  Unmarshaller
+}
+import _root_.org.apache.pekko.http.scaladsl.common.EntityStreamingSupport
+import _root_.org.apache.pekko.http.scaladsl.marshalling._
+import _root_.org.apache.pekko.http.scaladsl.model._
+import _root_.org.apache.pekko.http.scaladsl.util.FastFuture
+import _root_.org.apache.pekko.http.scaladsl.util.FastFuture._
+import _root_.org.apache.pekko.stream.scaladsl.{Flow, Keep, Source}
+import _root_.org.apache.pekko.util.ByteString
+import _root_.org.apache.pekko.NotUsed
+import io.bullet.borer._
+
+trait PekkoHttpCompat {
+
+  // brevity aliases
+  type CborDecodingSetup = DecodingSetup.Api[Cbor.DecodingConfig]
+  type JsonDecodingSetup = DecodingSetup.Api[Json.DecodingConfig]
+
+  /**
+   * Override with a parameterized call to the `borerUnmarshaller` method to apply a custom configuration.
+   */
+  implicit def borerFromEntityUnmarshaller[T: Decoder]: FromEntityUnmarshaller[T] = borerUnmarshaller()
+
+  implicit final def borerFromMessageUnmarshaller[T: Decoder]: FromMessageUnmarshaller[T] =
+    Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(borerFromEntityUnmarshaller)
+
+  /**
+   * Provides a [[FromEntityUnmarshaller]] for [[T]] given an implicit borer Decoder for [[T]].
+   * Supports both CBOR and JSON with the given MediaTypes.
+   */
+  final def borerUnmarshaller[T: Decoder](
+      cborMediaType: MediaType = MediaTypes.`application/cbor`,
+      jsonMediaType: MediaType = MediaTypes.`application/json`,
+      configureCbor: CborDecodingSetup => CborDecodingSetup = identity,
+      configureJson: JsonDecodingSetup => JsonDecodingSetup = identity
+  ): FromEntityUnmarshaller[T] =
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => httpEntity =>
+      pekkoHttp.byteArrayUnmarshaller(httpEntity).fast.flatMap { bytes =>
+        if (bytes.length > 0) {
+          httpEntity.contentType.mediaType match {
+            case `cborMediaType` => FastFuture(configureCbor(Cbor.decode(bytes)).to[T].valueTry)
+            case `jsonMediaType` => FastFuture(configureJson(Json.decode(bytes)).to[T].valueTry)
+            case _ => FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(cborMediaType, jsonMediaType))
+          }
+        } else FastFuture.failed(Unmarshaller.NoContentException)
+      }
+    }
+
+  /**
+   * Provides a [[FromEntityUnmarshaller]] for [[T]] given an implicit borer Decoder for [[T]].
+   * Supports only CBOR with the given MediaType.
+   */
+  final def borerCborUnmarshaller[T: Decoder](
+      cborMediaType: MediaType = MediaTypes.`application/cbor`,
+      configureCbor: CborDecodingSetup => CborDecodingSetup = identity): FromEntityUnmarshaller[T] =
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => httpEntity =>
+      pekkoHttp.byteArrayUnmarshaller(httpEntity).fast.flatMap { bytes =>
+        if (bytes.length > 0) {
+          httpEntity.contentType.mediaType match {
+            case `cborMediaType` => FastFuture(configureCbor(Cbor.decode(bytes)).to[T].valueTry)
+            case _               => FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(cborMediaType))
+          }
+        } else FastFuture.failed(Unmarshaller.NoContentException)
+      }
+    }
+
+  /**
+   * Provides a [[FromEntityUnmarshaller]] for [[T]] given an implicit borer Decoder for [[T]].
+   * Supports only JSON with the given MediaType.
+   */
+  final def borerJsonUnmarshaller[T: Decoder](
+      jsonMediaType: MediaType = MediaTypes.`application/json`,
+      configureJson: JsonDecodingSetup => JsonDecodingSetup = identity
+  ): FromEntityUnmarshaller[T] =
+    Unmarshaller.withMaterializer { implicit ec => implicit mat => httpEntity =>
+      pekkoHttp.byteArrayUnmarshaller(httpEntity).fast.flatMap { bytes =>
+        if (bytes.length > 0) {
+          httpEntity.contentType.mediaType match {
+            case `jsonMediaType` => FastFuture(configureJson(Json.decode(bytes)).to[T].valueTry)
+            case _               => FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(jsonMediaType))
+          }
+        } else FastFuture.failed(Unmarshaller.NoContentException)
+      }
+    }
+
+  // brevity aliases
+  type CborEncodingSetup = EncodingSetup.Api[Cbor.EncodingConfig]
+  type JsonEncodingSetup = EncodingSetup.Api[Json.EncodingConfig]
+
+  /**
+   * Override with a parameterized call to the `borerMarshaller` method to apply a custom configuration.
+   */
+  implicit def borerToEntityMarshaller[T: Encoder]: ToEntityMarshaller[T] = borerMarshaller()
+
+  implicit final def borerToResponseMarshaller[T: Encoder]: ToResponseMarshaller[T] =
+    Marshaller.liftMarshaller(borerToEntityMarshaller)
+
+  /**
+   * Provides a [[ToEntityMarshaller]] for [[T]] given an implicit borer Encoder for [[T]].
+   * Supports both CBOR and JSON with the given MediaTypes.
+   * Content negotiation will determine, whether CBOR or JSON is produced.
+   * If the client accepts both formats with equal q-value the marshaller will produce
+   * whatever the `prefer` parameter specifies.
+   */
+  final def borerMarshaller[T: Encoder](
+      cborContentType: ContentType = MediaTypes.`application/cbor`,
+      jsonContentType: ContentType = MediaTypes.`application/json`,
+      configureCbor: CborEncodingSetup => CborEncodingSetup = identity,
+      configureJson: JsonEncodingSetup => JsonEncodingSetup = identity,
+      prefer: Target = Json
+  ): ToEntityMarshaller[T] = {
+    val cborMarshaller = borerCborMarshaller(cborContentType, configureCbor)
+    val jsonMarshaller = borerJsonMarshaller(jsonContentType, configureJson)
+    if (prefer == Cbor)
+      Marshaller.oneOf(cborMarshaller, jsonMarshaller)
+    else
+      Marshaller.oneOf(jsonMarshaller, cborMarshaller)
+  }
+
+  /**
+   * Provides a [[ToEntityMarshaller]] for [[T]] given an implicit borer Encoder for [[T]].
+   * Supports only CBOR with the given MediaType.
+   */
+  final def borerCborMarshaller[T: Encoder](
+      cborContentType: ContentType = MediaTypes.`application/cbor`,
+      configureCbor: CborEncodingSetup => CborEncodingSetup = identity): ToEntityMarshaller[T] =
+    Marshaller.byteArrayMarshaller(cborContentType).compose[T] { value =>
+      configureCbor(Cbor.encode(value)).toByteArray
+    }
+
+  /**
+   * Provides a [[ToEntityMarshaller]] for [[T]] given an implicit borer Encoder for [[T]].
+   * Supports only JSON with the given MediaType.
+   */
+  final def borerJsonMarshaller[T: Encoder](
+      jsonContentType: ContentType = MediaTypes.`application/json`,
+      configureJson: JsonEncodingSetup => JsonEncodingSetup = identity
+  ): ToEntityMarshaller[T] =
+    Marshaller.byteArrayMarshaller(jsonContentType).compose[T] { value =>
+      configureJson(Json.encode(value)).toByteArray
+    }
+
+  /**
+   * Override with a parameterized call to the `borerStreamUnmarshaller` method to apply a custom configuration.
+   */
+  implicit def borerJsonStreamFromEntityUnmarshaller[T: Decoder]: FromEntityUnmarshaller[Source[T, NotUsed]] =
+    borerStreamUnmarshaller(EntityStreamingSupport.json())
+
+  implicit final def borerJsonStreamFromMessageUnmarshaller[T: Decoder]: FromMessageUnmarshaller[Source[T, NotUsed]] =
+    Unmarshaller.messageUnmarshallerFromEntityUnmarshaller(borerJsonStreamFromEntityUnmarshaller)
+
+  /**
+   * Provides a [[FromEntityUnmarshaller]] which produces streams of [[T]] given an implicit borer Decoder
+   * for [[T]]. Supports JSON or CSV, depending on the given [[EntityStreamingSupport]].
+   *
+   * @see https://doc.pekko.io/api/pekko-http/10.1.9/pekko/http/scaladsl/common/EntityStreamingSupport.html
+   */
+  final def borerStreamUnmarshaller[T: Decoder](
+      ess: EntityStreamingSupport): FromEntityUnmarshaller[Source[T, NotUsed]] =
+    Unmarshaller.withMaterializer { implicit ec => implicit mat =>
+      val unmarshalSync = (byteString: ByteString) => Json.decode(byteString.toArray[Byte]).to[T].value
+      val unmarshallingFlow =
+        if (ess.parallelism > 1) {
+          val unmarshalAsync = (byteString: ByteString) => Future(unmarshalSync(byteString))
+          if (ess.unordered) Flow[ByteString].mapAsyncUnordered(ess.parallelism)(unmarshalAsync)
+          else Flow[ByteString].mapAsync(ess.parallelism)(unmarshalAsync)
+        } else Flow[ByteString].map(unmarshalSync)
+
+      httpEntity => {
+        if (ess.supported matches httpEntity.contentType) {
+          val frames = httpEntity.dataBytes.via(ess.framingDecoder)
+          FastFuture.successful(frames.viaMat(unmarshallingFlow)(Keep.right))
+        } else FastFuture.failed(Unmarshaller.UnsupportedContentTypeException(ess.supported))
+      }
+    }
+
+  /**
+   * Override with a parameterized call to the `borerStreamMarshaller` method to apply a custom configuration.
+   */
+  implicit def borerJsonStreamToEntityMarshaller[T: ToEntityMarshaller: ClassTag]
+      : ToEntityMarshaller[Source[T, NotUsed]] =
+    borerStreamMarshaller[T](EntityStreamingSupport.json())
+
+  implicit final def borerJsonStreamToResponseMarshaller[T: ToEntityMarshaller: ClassTag]
+      : ToResponseMarshaller[Source[T, NotUsed]] =
+    Marshaller.liftMarshaller(borerJsonStreamToEntityMarshaller)
+
+  /**
+   * Provides a [[ToEntityMarshaller]] for streams of [[T]] given an implicit borer Encoder for [[T]].
+   * Supports JSON or CSV, depending on the given [[EntityStreamingSupport]].
+   */
+  final def borerStreamMarshaller[T](ess: EntityStreamingSupport)(
+      implicit marshaller: ToEntityMarshaller[T],
+      classTag: ClassTag[T]): ToEntityMarshaller[Source[T, NotUsed]] = {
+
+    type Marshallings = List[Marshalling[MessageEntity]]
+    val contentType = ess.contentType
+    val selectMarshalling: Marshallings => Option[() => MessageEntity] =
+      contentType match {
+        case _: ContentType.Binary | _: ContentType.WithFixedCharset | _: ContentType.WithMissingCharset =>
+          (_: Marshallings).collectFirst { case Marshalling.WithFixedContentType(`contentType`, marshal) => marshal }
+        case ContentType.WithCharset(mediaType, charset) =>
+          (_: Marshallings).collectFirst {
+            case Marshalling.WithFixedContentType(`contentType`, marshal) => marshal
+            case Marshalling.WithOpenCharset(`mediaType`, marshal)        => () => marshal(charset)
+          }
+      }
+
+    Marshaller[Source[T, NotUsed], MessageEntity] { implicit ec => source =>
+      FastFuture successful {
+        Marshalling.WithFixedContentType(
+          contentType,
+          () => {
+            val byteStream =
+              source
+                .mapAsync(1)(value => marshaller(value)(ec))
+                .map { marshallings =>
+                  selectMarshalling(marshallings)
+                    .orElse(marshallings collectFirst { case Marshalling.Opaque(x) => x })
+                    .getOrElse(
+                      throw new NoStrictlyCompatibleElementMarshallingAvailableException[T](contentType, marshallings))
+                }
+                .flatMapConcat(_.apply().dataBytes) // marshal!
+                .via(ess.framingRenderer)
+
+            HttpEntity(contentType, byteStream)
+          }) :: Nil
+      }
+    }
+  }
+}
+
+/**
+ * Automatic to and from CBOR and/or JSON marshalling/unmarshalling using in-scope borer Encoders / Decoders.
+ */
+object pekkoHttp extends PekkoHttpCompat {
+
+  private[compat] val byteArrayUnmarshaller: FromEntityUnmarshaller[Array[Byte]] =
+    Unmarshaller.byteArrayUnmarshaller
+}

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/MiscSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/MiscSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import _root_.org.apache.pekko.util.ByteString
+import _root_.org.apache.pekko.actor.ActorSystem as ClassicActorSystem
+import _root_.org.apache.pekko.actor
+import _root_.org.apache.pekko.actor.typed.{ActorRef, ActorSystem}
+import _root_.org.apache.pekko.actor.typed.scaladsl.Behaviors
+import io.bullet.borer._
+import io.bullet.borer.derivation.ArrayBasedCodecs
+
+class MiscSpec extends AbstractBorerSpec {
+  import org.apache.pekko._
+
+  def encode[T: Encoder](value: T): String   = toHexString(Cbor.encode(value).to[ByteString].result.toArray)
+  def decode[T: Decoder](encoded: String): T = Cbor.decode(ByteString(hexBytes(encoded))).to[T].value
+
+  case class Foo(int: Int, content: ByteString)
+
+  implicit val fooCodec: Codec[Foo] = ArrayBasedCodecs.deriveCodec[Foo]
+
+  test("roundtrip to and from ByteString") {
+    roundTrip(
+      "83820b40820c476f682079656168820d43ff0001",
+      Vector(
+        Foo(11, ByteString.empty),
+        Foo(12, ByteString("oh yeah")),
+        Foo(13, ByteString(-1, 0, 1))
+      )
+    )
+  }
+
+  test("roundtrip classic ActorRef") {
+
+    class SomeActor extends actor.Actor {
+      def receive = ???
+    }
+
+    implicit val system = actor.ActorSystem()
+    val actorRef        = system.actorOf(actor.Props[SomeActor](), "some")
+
+    decode[actor.ActorRef](encode(actorRef)) ==> actorRef
+  }
+
+  test("roundtrip typed ActorRef") {
+    val system                                      = ActorSystem(Behaviors.ignore[Int], "some")
+    val actorRef: ActorRef[Int]                     = system
+    implicit def implicitSystem: ClassicActorSystem = system.classicSystem
+
+    decode[ActorRef[Int]](encode(actorRef)) ==> actorRef
+  }
+}

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/MiscSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/MiscSpec.scala
@@ -17,7 +17,7 @@ import io.bullet.borer._
 import io.bullet.borer.derivation.ArrayBasedCodecs
 
 class MiscSpec extends AbstractBorerSpec {
-  import org.apache.pekko._
+  import pekko._
 
   def encode[T: Encoder](value: T): String   = toHexString(Cbor.encode(value).to[ByteString].result.toArray)
   def decode[T: Decoder](encoded: String): T = Cbor.decode(ByteString(hexBytes(encoded))).to[T].value

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoCborSuiteSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoCborSuiteSpec.scala
@@ -12,7 +12,7 @@ import _root_.org.apache.pekko.util.ByteString
 import io.bullet.borer._
 
 class PekkoCborSuiteSpec extends AbstractCborSuiteSpec {
-  import org.apache.pekko._
+  import pekko._
 
   def encode[T: Encoder](value: T): String   = toHexString(Cbor.encode(value).to[ByteString].result.toArray)
   def decode[T: Decoder](encoded: String): T = Cbor.decode(ByteString(hexBytes(encoded))).to[T].value

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoCborSuiteSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoCborSuiteSpec.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import _root_.org.apache.pekko.util.ByteString
+import io.bullet.borer._
+
+class PekkoCborSuiteSpec extends AbstractCborSuiteSpec {
+  import org.apache.pekko._
+
+  def encode[T: Encoder](value: T): String   = toHexString(Cbor.encode(value).to[ByteString].result.toArray)
+  def decode[T: Decoder](encoded: String): T = Cbor.decode(ByteString(hexBytes(encoded))).to[T].value
+}

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoHttpSupportSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoHttpSupportSpec.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import _root_.org.apache.pekko.actor.ActorSystem
+import _root_.org.apache.pekko.http.scaladsl.marshalling.{Marshal, ToEntityMarshaller}
+import _root_.org.apache.pekko.http.scaladsl.model._
+import _root_.org.apache.pekko.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import _root_.org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import _root_.org.apache.pekko.stream.scaladsl.{Sink, Source}
+import _root_.org.apache.pekko.util.ByteString
+import _root_.org.apache.pekko.NotUsed
+import _root_.org.apache.pekko.http.scaladsl.model.MediaTypes.{`application/cbor`, `application/json`}
+import io.bullet.borer.{BorerSuite, Cbor, Codec, Encoder}
+import io.bullet.borer.derivation.MapBasedCodecs
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+/**
+ * More or less direct adaptation of
+ * https://github.com/hseeberger/pekko-http-json/blob/7a700166e962ec77cdea1a222e219ec78ca1175c/pekko-http-jsoniter-scala/src/test/scala/de/heikoseeberger/pekkohttpjsoniterscala/JsoniterScalaSupportSpec.scala
+ * which is copyright by Heiko Seeberger and licensed under Apache License, Version 2.0.
+ */
+class PekkoHttpSupportSpec extends BorerSuite {
+  import org.apache.pekkoHttp._
+
+  final case class Foo(bar: String) {
+    require(bar == "bar", "bar must be 'bar'!")
+  }
+
+  final case class Num(x: Int)
+
+  implicit private val system: ActorSystem = ActorSystem()
+  import system.dispatcher
+
+  implicit private val fooCodec: Codec[Foo] = MapBasedCodecs.deriveCodec[Foo]
+  implicit private val numCodec: Codec[Num] = MapBasedCodecs.deriveCodec[Num]
+
+  test("marshalling and unmarshalling (CBOR)") {
+    implicit def borerToEntityMarshaller[T: Encoder]: ToEntityMarshaller[T] = borerMarshaller(prefer = Cbor)
+
+    val foo = Foo("bar")
+    Marshal(foo)
+      .to[RequestEntity]
+      .map { entity =>
+        entity.contentType ==> ContentType(`application/cbor`)
+        entity
+      }
+      .flatMap(Unmarshal(_).to[Foo])
+      .map(_ ==> foo)
+  }
+
+  test("marshalling and unmarshalling (JSON)") {
+    val foo = Foo("bar")
+    Marshal(foo)
+      .to[RequestEntity]
+      .map { entity =>
+        entity.contentType ==> ContentType(`application/json`)
+        entity
+      }
+      .flatMap(Unmarshal(_).to[Foo])
+      .map(_ ==> foo)
+  }
+
+  test("prefer JSON on equal q-value (by default)") {
+    val foo = Foo("bar")
+    val acceptHeader = _root_.org.apache.pekko.http.scaladsl.model.headers.Accept(
+      MediaRange.One(`application/json`, 1.0f),
+      MediaRanges.`*/*`
+    )
+    Marshal(foo)
+      .toResponseFor(HttpRequest(headers = acceptHeader :: Nil))
+      .flatMap(_.entity.toStrict(1.second))
+      .map(_ ==> HttpEntity.Strict(`application/json`, ByteString("""{"bar":"bar"}""")))
+  }
+
+  test("surface error message for requirement errors") {
+    val entity = HttpEntity(`application/json`, """{ "bar": "baz" }""")
+    Unmarshal(entity)
+      .to[Foo]
+      .failed
+      .map(_.getMessage ==> "java.lang.IllegalArgumentException: requirement failed: bar must be 'bar'! (input position 15)")
+  }
+
+  test("fail with NoContentException when unmarshalling empty entities") {
+    val entity = HttpEntity.empty(ContentTypes.`application/json`)
+    Unmarshal(entity)
+      .to[Foo]
+      .failed
+      .map(_ ==> Unmarshaller.NoContentException)
+  }
+
+  test("fail with UnsupportedContentTypeException when Content-Type is not `application/json`") {
+    val entity = HttpEntity("""{ "bar": "bar" }""")
+    Unmarshal(entity)
+      .to[Foo]
+      .failed
+      .map(_ ==> UnsupportedContentTypeException(ContentType(`application/cbor`), ContentTypes.`application/json`))
+  }
+
+  test("stream unmarshalling (JSON)") {
+    val entity = HttpEntity(`application/json`, """[{"x":1},{"x":2},{"x":3}]""")
+    Unmarshal(entity)
+      .to[Source[Num, NotUsed]]
+      .flatMap(_.runWith(Sink.seq))
+      .map(_ ==> List(Num(1), Num(2), Num(3)))
+  }
+
+  test("stream marshalling (JSON)") {
+    val nums = List(Num(1), Num(2), Num(3))
+    val acceptHeader =
+      _root_.org.apache.pekko.http.scaladsl.model.headers.Accept(MediaRange.One(`application/json`, 1.0f))
+    Marshal(nums)
+      .toResponseFor(HttpRequest(headers = acceptHeader :: Nil))
+      .flatMap(_.entity.toStrict(1.second))
+      .map { entity =>
+        entity.contentType ==> ContentTypes.`application/json`
+        entity.data.utf8String ==> """[{"x":1},{"x":2},{"x":3}]"""
+      }
+  }
+
+  override def afterAll(): Unit = Await.ready(system.terminate(), 4.seconds)
+}

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoHttpSupportSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoHttpSupportSpec.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.DurationInt
  * which is copyright by Heiko Seeberger and licensed under Apache License, Version 2.0.
  */
 class PekkoHttpSupportSpec extends BorerSuite {
-  import org.apache.pekkoHttp._
+  import pekkoHttp._
 
   final case class Foo(bar: String) {
     require(bar == "bar", "bar must be 'bar'!")

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoJsonSuiteSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoJsonSuiteSpec.scala
@@ -14,7 +14,7 @@ import _root_.org.apache.pekko.util.ByteString
 import io.bullet.borer._
 
 class PekkoJsonSuiteSpec extends AbstractJsonSuiteSpec {
-  import org.apache.pekko._
+  import pekko._
 
   def encode[T: Encoder](value: T): String =
     Json.encode(value).to[ByteString].result.utf8String

--- a/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoJsonSuiteSpec.scala
+++ b/compat-pekko/src/test/scala/io/bullet/borer/compat/PekkoJsonSuiteSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-2023 Mathias Doenitz
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package io.bullet.borer.compat
+
+import java.nio.charset.StandardCharsets
+
+import _root_.org.apache.pekko.util.ByteString
+import io.bullet.borer._
+
+class PekkoJsonSuiteSpec extends AbstractJsonSuiteSpec {
+  import org.apache.pekko._
+
+  def encode[T: Encoder](value: T): String =
+    Json.encode(value).to[ByteString].result.utf8String
+
+  def decode[T: Decoder](encoded: String): T =
+    Json
+      .decode(ByteString(encoded getBytes StandardCharsets.UTF_8))
+      .withConfig(Json.DecodingConfig.default.copy(maxNumberAbsExponent = 300))
+      .to[T]
+      .value
+}

--- a/site/src/main/paradox/borer-compat-peko.md
+++ b/site/src/main/paradox/borer-compat-peko.md
@@ -1,0 +1,53 @@
+`borer-compat-pekko`
+==================
+
+`ByteString` support
+--------------------
+
+The @ref:[`borer-core`](borer-core/index.md) module by itself only knows how to encode to and decode from plain byte
+arrays (`Array[Byte]`) and a few other types (like `java.nio.ByteBuffer`, see the chapter on
+@ref:[Input, Output, ByteAccess](borer-core/supporting-typeclasses.md) for full details).
+
+When you include the `borer-compat-pekko` module as a dependency (see the
+@ref:[Getting Started](getting-started.md) chapter for details) and
+
+```scala
+import io.bullet.borer.compat.pekko._
+```
+
+you also get:
+
+- full "zero-copy" support for encoding to and decoding from `pekko.util.ByteString`
+- implicit codecs for `pekko.util.ByteString`, `pekko.actor.ActorRef` and `pekko.actor.typed.ActorRef[T]`
+
+
+Pekko Http (Un)Marshalling
+-------------------------
+
+In addition to `ByteString` support the `borer-compat-pekko` also provides convenient marshallers and unmarshallers
+for HTTP entities.
+
+When you include the `borer-compat-pekko` module as a dependency (see the
+@ref:[Getting Started](getting-started.md) chapter for details) and
+
+```scala
+import io.bullet.borer.compat.pekkoHttp._
+```
+
+`pekko-http` will transparently marshal to and from your custom domain model types:
+
+@@snip [-]($test$/PekkoHttpSupportSpec.scala) { #example }
+
+By default the `Unmarshaller` constructed by `borer-compat-pekko` understand both [CBOR] and [JSON] with Content-Type
+`application/cbor` and `application/json`, respectively.<br>
+The `Marshaller` also supports both formats and lets the client determine via HTTP content negotiation (i.e. the
+`Accept` header) , which one it prefers. If the client has no clear preference, i.e. it accepts both [CBOR] and [JSON]
+with equal "q-value" (preference weight) the `Marshaller` choses [JSON] by default. This default, however, can be
+configured to [CBOR] if needed.
+
+(Un)marshaller construction can be customized in various ways, e.g. with custom media types, and is also available
+for streams, i.e. to and from `pekko.stream.scaladsl.Source[T, _]` rather than simply `T`.<br>
+Check out the @github[sources](/compat-pekko/src/main/scala/io/bullet/borer/compat/pekkoHttp.scala) for full details.
+
+[CBOR]: http://cbor.io/
+[JSON]: http://json.org/ 

--- a/site/src/main/paradox/borer-core/supporting-typeclasses.md
+++ b/site/src/main/paradox/borer-core/supporting-typeclasses.md
@@ -22,6 +22,7 @@ Currently _borer_ comes with predefined `Input` implementations for these types:
 - `java.io.InputStream`
 - `java.io.File`
 - `akka.util.ByteString` (with the `borer-compat-akka` module)
+- `pekko.util.ByteString` (with the `borer-compat-pekko` module)
 - `scodec.bits.ByteVector` (with the `borer-compat-scodec` module)
 - `Iterator[T]`, provided that there is an `Input.Provider[T]` available implicitly
 
@@ -49,6 +50,7 @@ implementations for these types:
 - `java.io.OutputStream` (to a an existing instance)
 - `java.io.File` (to a an existing instance)
 - `akka.util.ByteString` (with the `borer-compat-akka` module)
+- `pekko.util.ByteString` (with the `borer-compat-pekko` module)
 - `scodec.bits.ByteVector` (with the `borer-compat-scodec` module)
 
 The @github[Output](/core/src/main/scala/io/bullet/borer/Output.scala) trait isn't hard to implement as it simply writes
@@ -72,4 +74,5 @@ implementations for these types:
 - `Array[Byte]`
 - `java.nio.ByteBuffer`
 - `akka.util.ByteString` (with the `borer-compat-akka` module)
+- `pekko.util.ByteString` (with the `borer-compat-pekko` module)
 - `scodec.bits.ByteVector` (with the `borer-compat-scodec` module)

--- a/site/src/main/paradox/getting-started.md
+++ b/site/src/main/paradox/getting-started.md
@@ -9,6 +9,7 @@ _borer_ consists of these modules:
 - @ref:[`borer-core`](borer-core/index.md), the actual core logic (no dependencies)
 - @ref:[`borer-derivation`](borer-derivation/index.md), (semi-)automatic codec derivation for case classes and ADTs<br>(no dependencies, relies on macros)
 - @ref:[`borer-compat-akka`](borer-compat-akka.md), support for `akka.util.ByteString` and `akka-http` (un)marshalling<br>(has a `provided` dependency on [akka-actor], [akka-stream] and [akka-http])
+- @ref:[`borer-compat-pekko`](borer-compat-pekko.md), support for `pekko.util.ByteString` and `pekko-http` (un)marshalling<br>(has a `provided` dependency on [pekko-actor], [pekko-stream] and [pekko-http])
 - @ref:[`borer-compat-cats`](borer-compat-cats.md), support for popular [cats] data structures from the `cats.data._` package (has a `provided` dependency on `cats-core`)
 - @ref:[`borer-compat-circe`](borer-compat-circe.md), seamless integration with [circe] codecs<br>(has a `provided` dependency on [circe])
 - @ref:[`borer-compat-scodec`](borer-compat-scodec.md), support for `scodec.bits.ByteVector`<br>(has a `provided` dependency on [scodec])
@@ -23,6 +24,7 @@ The artifacts for _borer_ live on Maven Central and can be tied into your projec
   group="io.bullet" artifact="borer-core_3" version="$project.version$"
   group2="io.bullet" artifact2="borer-derivation_3" version2="$project.version$"
   group3="io.bullet" artifact3="borer-compat-akka_3" version3="$project.version$"
+  group3="io.bullet" artifact3="borer-compat-pekko_3" version3="$project.version$"
   group3="io.bullet" artifact3="borer-compat-cats_3" version4="$project.version$"
   group4="io.bullet" artifact4="borer-compat-circe_3" version5="$project.version$"
   group5="io.bullet" artifact5="borer-compat-scodec_3" version6="$project.version$"
@@ -39,6 +41,9 @@ The latest version supporting Scala 2.12 is `1.7.2`.
   [akka-actor]: https://doc.akka.io/docs/akka/2.5/actors.html#dependency
   [akka-stream]: https://doc.akka.io/docs/akka/current/stream/index.html
   [akka-http]: https://doc.akka.io/docs/akka-http/current/index.html
+  [pekko-actor]: https://pekko.apache.org/docs/pekko/current/general/actors.html
+  [pekko-stream]: https://pekko.apache.org/docs/pekko/current/stream/index.html
+  [pekko-http]: https://pekko.apache.org/docs/pekko-http/current/
   [cats]: https://typelevel.org/cats/
   [circe]: https://circe.github.io/circe/
   [scodec]: http://scodec.org/

--- a/site/src/main/paradox/index.md
+++ b/site/src/main/paradox/index.md
@@ -41,7 +41,7 @@ Debuggable
   serialization issues, especially when working with a binary format like [CBOR].
 
 Scala JS
-: All _borer_ modules (except for `borer-compat-akka`) support [scala.js].
+: All _borer_ modules (except for `borer-compat-akka` and `borer-compat-pekko`) support [scala.js].
 
 
   [Scala]: https://www.scala-lang.org/
@@ -57,6 +57,7 @@ Scala JS
 * [-](borer-core/index.md)
 * [-](borer-derivation/index.md)
 * [-](borer-compat-akka.md)
+* [-](borer-compat-pekko.md)
 * [-](borer-compat-cats.md)
 * [-](borer-compat-circe.md)
 * [-](borer-compat-scodec.md)


### PR DESCRIPTION
The compat-pekko additions are a copy of compat-akka, with the names and dependencies changed.