### PR TITLE
Fix for missing target argument in Json.writer(...)

### DIFF
--- a/core/src/main/scala/io/bullet/borer/Borer.scala
+++ b/core/src/main/scala/io/bullet/borer/Borer.scala
@@ -211,7 +211,7 @@ case object Json extends Target:
       output: Output,
       config: EncodingConfig = EncodingConfig.default,
       receiverWrapper: Receiver.Transformer[EncodingConfig] = Receiver.nopTransformer): Writer =
-    new Writer(output, receiverWrapper(JsonRenderer(output, config), config), null, config)
+    new Writer(output, receiverWrapper(JsonRenderer(output, config), config), Json, config)
 
   /**
    * Constructs a new [[Reader]] that reads JSON from the given [[Input]].


### PR DESCRIPTION
See Issue #844. The `Json.writer(...)` returned an invalid `Writer` instance as it failed to properly supply a value for the `target` slot (it passed `null` instead of `this` or `Json`). This caused trouble down the line for all `Encoder` implementations that try to be output format aware